### PR TITLE
Test that keyword can not start in 0 column

### DIFF
--- a/src/ert_config_parser/__init__.py
+++ b/src/ert_config_parser/__init__.py
@@ -1,5 +1,7 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
+from ._parse import parse
+
 __author__ = """Equinor"""
 __email__ = "fg_sib-scout@equinor.com"
 
@@ -7,3 +9,5 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     __version__ = "0.0.0"
+
+__all__ = ["parse"]

--- a/src/ert_config_parser/_parse.py
+++ b/src/ert_config_parser/_parse.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from warnings import warn
+
+
+def tokenize(line):
+    in_string = False
+    tokens = []
+    current_token = ""
+    started_dash = False
+    for index in range(len(line)):
+        if line[index] == '"':
+            started_dash = False
+            if current_token:
+                tokens.append(current_token)
+                current_token = ""
+            in_string = not in_string
+            continue
+        if in_string:
+            current_token += line[index]
+        else:
+            if line[index] == "-":
+                if started_dash:
+                    current_token = current_token[:-1]
+                    break
+                else:
+                    started_dash = True
+            else:
+                started_dash = False
+            if line[index] == " ":
+                if current_token:
+                    tokens.append(current_token)
+                    current_token = ""
+            else:
+                current_token += line[index]
+    if current_token:
+        tokens.append(current_token)
+
+    if in_string:
+        raise ValueError("Unmatched quote")
+    return tokens
+
+
+def parse(filename, keywords):
+    file_contents = Path(filename).read_text().split("\n")
+    results = {}
+    for line in file_contents:
+        tokens = tokenize(line)
+        if not tokens:
+            continue
+        keyword = tokens[0]
+        if keyword in keywords:
+            results[keyword] = tokens[1:]
+        else:
+            warn(f"Unrecognized keyword {keyword}")
+    return results

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,0 +1,79 @@
+import pytest
+
+from ert_config_parser import parse
+from ert_config_parser._parse import tokenize
+
+test_file = "test.ert"
+
+
+def test_tokenize():
+    assert tokenize("my token") == ["my", "token"]
+    assert tokenize('"my" token') == ["my", "token"]
+    with pytest.raises(ValueError):
+        tokenize('"my ')
+    assert tokenize('"my token"') == ["my token"]
+    assert tokenize("my token -- comment") == ["my", "token"]
+    assert tokenize("my token--comment") == ["my", "token"]
+    assert tokenize('"my token"token2"token3"') == ["my token", "token2", "token3"]
+
+
+def write_config(filename, content):
+    with open(filename, "w") as f:
+        f.write(content)
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        (
+            """ NUM_REALIZATIONS 100
+RANDOM_SEED 1234""",
+            ["1234"],
+        ),
+        (
+            """ NUM_REALIZATIONS 100
+RANDOM_SEED \"1234\"""",
+            ["1234"],
+        ),
+        (
+            """ NUM_REALIZATIONS 100,
+RANDOM_SEED 1234 -- comment""",
+            ["1234"],
+        ),
+        (
+            """ NUM_REALIZATIONS 100
+RANDOM_SEED \"1234 1234\"""",
+            ["1234 1234"],
+        ),
+        (
+            """ NUM_REALIZATIONS 100
+                RANDOM_SEED \"1234 1234\"""",
+            ["1234 1234"],
+        ),
+        (
+            """ NUM_REALIZATIONS 100
+RANDOM_SEED 1234 1234""",
+            ["1234", "1234"],
+        ),
+        ('RANDOM_SEED 1234 "12 34--"', ["1234", "12 34--"]),
+        ('"RANDOM_SEED" 1234 "12 34--"', ["1234", "12 34--"]),  # edge case
+    ],
+)
+def test_parse_random_seed_config(content, expected, tmp_path):
+    write_config(tmp_path / test_file, content)
+    assert parse(tmp_path / test_file, keywords=["RANDOM_SEED"]) == {
+        "RANDOM_SEED": expected
+    }
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        '"RANDOM_SEED " 1234',
+        "random_seed 1234",
+        '"random_seed 1234"',
+    ],
+)
+def test_parse_ignores_not_the_keyword(contents, tmp_path):
+    write_config(tmp_path / test_file, contents)
+    assert parse(tmp_path / test_file, keywords=["RANDOM_SEED"]) == {}


### PR DESCRIPTION
Adds the implementation from our kickoff meeting.

Also, adds another test case. The currently used implementation of the parser allows keywords to not start in 0 column so that is part of the spec.